### PR TITLE
Accept empty clientId in connect packet generation

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -41,7 +41,7 @@ function connect(opts) {
     , will = opts.will
     , clean = opts.clean
     , keepalive = opts.keepalive || 0
-    , clientId = opts.clientId
+    , clientId = opts.clientId || ""
     , username = opts.username
     , password = opts.password
 
@@ -70,12 +70,23 @@ function connect(opts) {
     length += 1
   }
 
-  // Must be a non-falsy string
-  if(!clientId ||
-     (typeof clientId !== "string" && !Buffer.isBuffer(clientId))) {
-    throw new Error('Invalid client id')
-  } else {
+  // ClientId might be omitted in 3.1.1, but only if cleanSession is set to 1
+  if((typeof clientId === "string" || Buffer.isBuffer(clientId)) &&
+     (clientId || protocolVersion == 4) &&
+     (clientId || clean)) {
+
     length += clientId.length + 2
+  } else {
+    
+    if(protocolVersion < 4) {
+    
+      throw new Error('clientId must be supplied before 3.1.1');
+    }
+    
+    if(clean == 0) {
+
+      throw new Error('clientId must be given if cleanSession set to 0');
+    } 
   }
 
   // Must be a two byte number

--- a/test.js
+++ b/test.js
@@ -116,6 +116,27 @@ testParseGenerate('minimal connect', {
   116, 101, 115, 116 // Client id
 ]))
 
+testParseGenerate('no clientId with 3.1.1', {
+    cmd: 'connect'
+  , retain: false
+  , qos: 0
+  , dup: false
+  , length: 12
+  , protocolId: 'MQTT'
+  , protocolVersion: 4
+  , clean: true
+  , keepalive: 30
+  , clientId: ''
+}, new Buffer([
+  16, 12, // Header
+  0, 4, // Protocol id length
+  77, 81, 84, 84, // Protocol id
+  4, // Protocol version
+  2, // Connect flags
+  0, 30, // Keepalive
+  0, 0, //Client id length
+]))
+
 testParseGenerateDefaults('default connect', {
     cmd: 'connect'
   , clientId: 'test'
@@ -633,7 +654,7 @@ testGenerateError('Invalid protocol id', {
   , password: 'password'
 })
 
-testGenerateError('Invalid client id', {
+testGenerateError('clientId must be supplied before 3.1.1', {
     cmd: 'connect'
   , retain: false
   , qos: 0
@@ -648,6 +669,26 @@ testGenerateError('Invalid client id', {
     , payload: 'payload'
     }
   , clean: true
+  , keepalive: 30
+  , username: 'username'
+  , password: 'password'
+})
+
+testGenerateError('clientId must be given if cleanSession set to 0', {
+    cmd: 'connect'
+  , retain: false
+  , qos: 0
+  , dup: false
+  , length: 54
+  , protocolId: 'MQTT'
+  , protocolVersion: 4
+  , will: {
+      retain: true
+    , qos: 2
+    , topic: 'topic'
+    , payload: 'payload'
+    }
+  , clean: false
   , keepalive: 30
   , username: 'username'
   , password: 'password'


### PR DESCRIPTION
MQTT 3.1.1 allows servers to accept client connections with zero-byte
clientIds, if the cleanSession flag is set to 1.

This commit allows the generation of a connect packet with empty clientId
(`clientId: null` or `clientId: ""`). The pre-conditions `protocolVersion == 4`
(MQTT 3.1.1) and `clean == 1` are validated.