### PR TITLE
Do not shift the pubcomp fixed header by qos

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -288,8 +288,6 @@ function confirmation(opts) {
 
   if (type === 'pubrel')
     qos = 1
-  else if (type === 'pubcomp')
-    qos = 2
 
   // Check message ID
   if ('number' !== typeof id)

--- a/test.js
+++ b/test.js
@@ -522,12 +522,12 @@ testParseGenerate('pubrel', {
 testParseGenerate('pubcomp', {
     cmd: 'pubcomp'
   , retain: false
-  , qos: 2
+  , qos: 0
   , dup: false
   , length: 2
   , messageId: 2
 }, new Buffer([
-  116, 2, // Header
+  112, 2, // Header
   0, 2 // Message id
 ]))
 


### PR DESCRIPTION
This improves mqtt 3.1.1 protocol compatibility and prevents HiveMQ 3 broker
from disconnecting the client after subscription.