### PR TITLE
Fixed crashing bug when parsing invalid messages

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -40,7 +40,7 @@ Parser.prototype.parse = function (buf) {
   this._list.append(buf)
 
   while ((this.packet.length != -1 || this._list.length > 0) &&
-         (noError = this[this._states[this._stateCounter]]())) {
+         this[this._states[this._stateCounter]]()) {
     this._stateCounter++
 
     if (this._stateCounter >= this._states.length) {

--- a/parser.js
+++ b/parser.js
@@ -39,20 +39,13 @@ Parser.prototype.parse = function (buf) {
 
   this._list.append(buf)
 
-  try {
+  while ((this.packet.length != -1 || this._list.length > 0) &&
+         (noError = this[this._states[this._stateCounter]]())) {
+    this._stateCounter++
 
-    while ((this.packet.length != -1 || this._list.length > 0) &&
-           (noError = this[this._states[this._stateCounter]]())) {
-      this._stateCounter++
-
-      if (this._stateCounter >= this._states.length) {
-        this._stateCounter = 0
-      }
+    if (this._stateCounter >= this._states.length) {
+      this._stateCounter = 0
     }
-  }
-  catch (e) {
-
-    return this.emit('error', e);
   }
 
   return this._list.length
@@ -101,7 +94,7 @@ Parser.prototype._parseLength = function () {
     this._list.consume(bytes)
   }
 
-  return result 
+  return result
 }
 
 Parser.prototype._parsePayload = function () {
@@ -171,7 +164,7 @@ Parser.prototype._parseConnect = function () {
   if (protocolId === null)
     return this.emit('error', new Error('cannot parse protocol id'))
 
-  if (['MQTT', 'MQIsdp'].indexOf(protocolId) < 0) {
+  if (protocolId != 'MQTT' && protocolId != 'MQIsdp') {
 
     return this.emit('error', new Error('invalid protocol id'))
   }
@@ -184,7 +177,7 @@ Parser.prototype._parseConnect = function () {
 
   packet.protocolVersion = this._list.readUInt8(this._pos)
 
-  if([3,4].indexOf(packet.protocolVersion) < 0) {
+  if(packet.protocolVersion != 3 && packet.protocolVersion != 4) {
 
     return this.emit('error', new Error('invalid protocol version'))
   }

--- a/test.js
+++ b/test.js
@@ -919,3 +919,16 @@ testParseError('invalid protocol version', new Buffer([
   0, 4, //Client id length
   116, 101, 115, 116 // Client id
 ]))
+
+testParseError('cannot parse protocol id', new Buffer([
+  16, 8,
+  0, 15,
+  77, 81, 73, 115, 100, 112,
+  77, 81, 73, 115, 100, 112,
+  77, 81, 73, 115, 100, 112,
+  77, 81, 73, 115, 100, 112,
+  77, 81, 73, 115, 100, 112,
+  77, 81, 73, 115, 100, 112,
+  77, 81, 73, 115, 100, 112,
+  77, 81, 73, 115, 100, 112
+]))

--- a/test.js
+++ b/test.js
@@ -879,3 +879,43 @@ test('support cork', function (t) {
 
   dest.end()
 })
+
+// the following test case was designed after experiencing errors
+// when trying to connect with tls on a non tls mqtt port
+// the specific behaviour is:
+// - first byte suggests this is a connect message
+// - second byte suggests message length to be smaller than buffer length
+//   thus payload processing starts
+// - the first two bytes suggest a protocol identifier string length
+//   that leads the parser pointer close to the end of the buffer
+// - when trying to read further connect flags the buffer produces
+//   a "out of range" Error
+//
+testParseError('packet too short', new Buffer([
+  16, 9,
+  0, 6,
+  77, 81, 73, 115, 100, 112,
+  3
+]))
+
+testParseError('invalid protocol id', new Buffer([
+  16, 18,
+  0, 6,
+  65,65,65,65,65,65, // AAAAAA
+  3, // protocol version
+  0, // connect flags
+  0, 10, // keep alive
+  0, 4, //Client id length
+  116, 101, 115, 116 // Client id
+]))
+
+testParseError('invalid protocol version', new Buffer([
+  16, 18,
+  0, 6,
+  77, 81, 73, 115, 100, 112, // Protocol id
+  1, // protocol version
+  0, // connect flags
+  0, 10, // keep alive
+  0, 4, //Client id length
+  116, 101, 115, 116 // Client id
+]))

--- a/test.js
+++ b/test.js
@@ -898,6 +898,9 @@ testParseError('packet too short', new Buffer([
   3
 ]))
 
+// CONNECT Packets that show other protocol ids than
+// the valid values MQTT and MQIsdp should cause an error
+// those packets are a hint that this is not a mqtt connection
 testParseError('invalid protocol id', new Buffer([
   16, 18,
   0, 6,
@@ -909,6 +912,8 @@ testParseError('invalid protocol id', new Buffer([
   116, 101, 115, 116 // Client id
 ]))
 
+// CONNECT Packets that contain an unsupported protocol version 
+// flag (i.e. not `3` or `4`) should cause an error
 testParseError('invalid protocol version', new Buffer([
   16, 18,
   0, 6,
@@ -920,9 +925,16 @@ testParseError('invalid protocol version', new Buffer([
   116, 101, 115, 116 // Client id
 ]))
 
+// when a packet contains a string in the variable header and the
+// given string length of this exceeds the overall length of the packet that 
+// was specified in the fixed header, parsing must fail.
+// this case simulates this behavior with the protocol id string of the
+// CONNECT packet. The fixed header suggests a remaining length of 8 bytes
+// which would be exceeded by the string length of 15
+// in this case, a protocol id parse error is expected
 testParseError('cannot parse protocol id', new Buffer([
-  16, 8,
-  0, 15,
+  16, 8, // fixed header
+  0, 15, // string length 15 --> 15 > 8 --> error!
   77, 81, 73, 115, 100, 112,
   77, 81, 73, 115, 100, 112,
   77, 81, 73, 115, 100, 112,


### PR DESCRIPTION
Fixes a crash that was observed in Mosca (https://github.com/mcollina/mosca/issues/393) when starting to parse a TLS encrypted stream while assuming to parse plain MQTT data.

So what happened? The TLS connect message that arrived at mosca looked like this:

```
<Buffer 16 03 01 01 01 01 00 00 fd 03 03 00 09 9a 85 fc 19 19 fa 06 a4
8c a5 53 5d 6e c1 01 23 be 68 00 85 b9 0c 29 8b 24 87 30 09 e6 e4 00 00
80 c0 2f c0 2b ... >
```

Note the `16` at the start, this suggests that we have a regular CONNECT packet. The next byte `3` suggests a remaining length of the packet of 3 bytes which is obviously not true, but the implementation of the parser just checks if at least 3 bytes remain in the buffer before it starts processing the payload.

The parseConnect function of the parser now checks the next two bytes `01 01` which would describe the protocol identifier string length. Usually this would be 4 or 6 bytes, but here we have 257 bytes. So the next 257 bytes are consumed into a string and our parsing pointer is at buffer position 259. Unfortunately, the buffer only has 260 bytes in total. That is why the next parsing steps produce an out of range exception..

We obviously have various problems here:

- the parser does not check for plausibility when a string ought to be longer than the packet
- the parser does not check for a valid protocol identifier string at all
- the parser does not check (at some points) if the buffer has remaining length before parsing the next bytes
- the parser does not catch any (further, unexpected) exceptions in order to safe the upper layers from running into bad behavior

All of these where fixed and respective tests added.