### PR TITLE
Fix issues when a float is used instead of a number

### DIFF
--- a/test.js
+++ b/test.js
@@ -754,6 +754,11 @@ testGenerateError('Invalid keepalive', {
   , password: 'password'
 })
 
+testGenerateError('Invalid keepalive', {
+    cmd: 'connect'
+    , keepalive: 3.1416
+})
+
 testGenerateError('Invalid will', {
     cmd: 'connect'
   , retain: false
@@ -912,7 +917,7 @@ testParseError('invalid protocol id', new Buffer([
   116, 101, 115, 116 // Client id
 ]))
 
-// CONNECT Packets that contain an unsupported protocol version 
+// CONNECT Packets that contain an unsupported protocol version
 // flag (i.e. not `3` or `4`) should cause an error
 testParseError('invalid protocol version', new Buffer([
   16, 18,
@@ -926,7 +931,7 @@ testParseError('invalid protocol version', new Buffer([
 ]))
 
 // when a packet contains a string in the variable header and the
-// given string length of this exceeds the overall length of the packet that 
+// given string length of this exceeds the overall length of the packet that
 // was specified in the fixed header, parsing must fail.
 // this case simulates this behavior with the protocol id string of the
 // CONNECT packet. The fixed header suggests a remaining length of 8 bytes

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -108,7 +108,8 @@ function connect(opts, stream) {
   // Must be a two byte number
   if ('number' !== typeof keepalive ||
       keepalive < 0 ||
-      keepalive > 65535) {
+      keepalive > 65535 ||
+      keepalive % 1 !== 0) {
     stream.emit('error', new Error('Invalid keepalive'))
   } else {
     length += 2
@@ -563,7 +564,7 @@ function writeBuffer(buffer, pos, src) {
  * @api private
  */
 function writeNumber(stream, number) {
-  return stream.write(numCache[number | 0])
+  return stream.write(numCache[number])
 }
 
 /**

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -563,7 +563,7 @@ function writeBuffer(buffer, pos, src) {
  * @api private
  */
 function writeNumber(stream, number) {
-  return stream.write(numCache[number])
+  return stream.write(numCache[number | 0])
 }
 
 /**


### PR DESCRIPTION
Some tests for MQTT.js use a float for the `keepalive` argument for mqtt.connect()

This fixes pending connections.

```
1) Websocket Client pinging should defer the next ping when sending a control packet:
     Error: timeout of 5000ms exceeded. Ensure the done() callback is being called in this test.
```