### PR TITLE
return on first error to avoid writing invalid bytes

### DIFF
--- a/test.js
+++ b/test.js
@@ -101,14 +101,16 @@ function testParseGenerateDefaults(name, object, buffer, opts) {
 
 function testWriteToStreamError(expected, fixture) {
   test('writeToStream ' + expected + ' error', function(t) {
-    t.plan(1)
+    t.plan(2)
 
     var stream = WS()
 
     stream.write = () => t.fail('should not have called write')
     stream.on('error', () => t.pass('error emitted'))
 
-    mqtt.writeToStream(fixture, stream)
+    var result = mqtt.writeToStream(fixture, stream)
+
+    t.false(result, 'result should be false')
   })
 }
 

--- a/test.js
+++ b/test.js
@@ -99,6 +99,19 @@ function testParseGenerateDefaults(name, object, buffer, opts) {
   })
 }
 
+function testWriteToStreamError(expected, fixture) {
+  test('writeToStream ' + expected + ' error', function(t) {
+    t.plan(1)
+
+    var stream = WS()
+
+    stream.write = () => t.fail('should not have called write')
+    stream.on('error', () => t.pass('error emitted'))
+
+    mqtt.writeToStream(fixture, stream)
+  })
+}
+
 testParseGenerate('minimal connect', {
     cmd: 'connect'
   , retain: false
@@ -1025,4 +1038,19 @@ test('stops parsing after first error', function(t) {
 
     224, 0, // Header
   ]))
+})
+
+testWriteToStreamError('Invalid protocol id', {
+  cmd: 'connect',
+  protocolId: {}
+})
+
+testWriteToStreamError('Invalid topic', {
+  cmd: 'publish',
+  topic: {}
+})
+
+testWriteToStreamError('Invalid message id', {
+  cmd: 'subscribe',
+  mid: {}
 })


### PR DESCRIPTION
I added `return` to all the lines that emit error events. This stops writing bytes to the output stream that we know are invalid.