### PR TITLE
Add option to enable/disable numbers cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ The object must be one of the ones specified by the [packets](#packets)
 section. Emits an `Error` on the stream if a packet cannot be generated.
 On node >= 0.12, this function automatically calls `cork()` on your stream,
 and then it calls `uncork()` on the next tick.
+By default cache for number buffers is enabled.
+It creates a list of buffers for faster write. To disable cache set `mqtt.writeToStream.cacheNumbers = false`
 
 <a name="parser">
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ section. Emits an `Error` on the stream if a packet cannot be generated.
 On node >= 0.12, this function automatically calls `cork()` on your stream,
 and then it calls `uncork()` on the next tick.
 By default cache for number buffers is enabled.
-It creates a list of buffers for faster write. To disable cache set `mqtt.writeToStream.cacheNumbers = false`
+It creates a list of buffers for faster write. To disable cache set `mqtt.writeToStream.cacheNumbers = false`.
+Should be set before any `writeToStream` calls.
 
 <a name="parser">
 

--- a/benchmarks/generate.js
+++ b/benchmarks/generate.js
@@ -1,10 +1,19 @@
+'use strict'
 
 var mqtt = require('../')
 var max = 100000
 var i
+var buf = Buffer.from('test')
+
+// initialize it
+mqtt.generate({
+  cmd: 'publish',
+  topic: 'test',
+  payload: buf
+})
+
 var start = Date.now()
 var time
-var buf = Buffer.from('test')
 
 for (i = 0; i < max; i++) {
   mqtt.generate({

--- a/numbers.js
+++ b/numbers.js
@@ -3,10 +3,9 @@
 var Buffer = require('safe-buffer').Buffer
 var max = 65536
 var cache = {}
-var buffer
 
 function generateBuffer (i) {
-  buffer = Buffer.allocUnsafe(2)
+  var buffer = Buffer.allocUnsafe(2)
   buffer.writeUInt8(i >> 8, 0, true)
   buffer.writeUInt8(i & 0x00FF, 0 + 1, true)
 
@@ -19,15 +18,7 @@ function generateCache () {
   }
 }
 
-function getCachedNumber (number) {
-  if (cache[number]) return cache[number]
-
-  generateCache()
-
-  return cache[number]
-}
-
 module.exports = {
-  getCachedNumber: getCachedNumber,
-  allocateNumber: generateBuffer
+  cache: cache,
+  generateCache: generateCache
 }

--- a/numbers.js
+++ b/numbers.js
@@ -5,11 +5,31 @@ var max = 65536
 var cache = {}
 var buffer
 
-for (var i = 0; i < max; i++) {
+function generateBuffer (i) {
   buffer = Buffer.allocUnsafe(2)
   buffer.writeUInt8(i >> 8, 0, true)
   buffer.writeUInt8(i & 0x00FF, 0 + 1, true)
-  cache[i] = buffer
+
+  return buffer
 }
 
-module.exports = cache
+function generateCache () {
+  for (var i = 0; i < max; i++) {
+    cache[i] = generateBuffer(i)
+  }
+}
+
+function get (number, cacheNumbers) {
+  if (cache[number]) return cache[number]
+
+  if (cacheNumbers) {
+    generateCache()
+    return cache[number]
+  }
+
+  return generateBuffer(number)
+}
+
+module.exports = {
+  get: get
+}

--- a/numbers.js
+++ b/numbers.js
@@ -19,17 +19,15 @@ function generateCache () {
   }
 }
 
-function get (number, cacheNumbers) {
+function getCachedNumber (number) {
   if (cache[number]) return cache[number]
 
-  if (cacheNumbers) {
-    generateCache()
-    return cache[number]
-  }
+  generateCache()
 
-  return generateBuffer(number)
+  return cache[number]
 }
 
 module.exports = {
-  get: get
+  getCachedNumber: getCachedNumber,
+  allocateNumber: generateBuffer
 }

--- a/numbers.js
+++ b/numbers.js
@@ -20,5 +20,6 @@ function generateCache () {
 
 module.exports = {
   cache: cache,
-  generateCache: generateCache
+  generateCache: generateCache,
+  generateNumber: generateBuffer
 }

--- a/test.js
+++ b/test.js
@@ -116,6 +116,40 @@ function testWriteToStreamError (expected, fixture) {
   })
 }
 
+test('disabled numbers cache', function (t) {
+  var stream = WS()
+  var message = {
+    cmd: 'publish',
+    retain: false,
+    qos: 0,
+    dup: false,
+    length: 10,
+    topic: Buffer.from('test'),
+    payload: Buffer.from('test')
+  }
+  var expected = Buffer.from([
+    48, 10, // Header
+    0, 4, // Topic length
+    116, 101, 115, 116, // Topic (test)
+    116, 101, 115, 116 // Payload (test)
+  ])
+  var written = Buffer.alloc(0)
+
+  stream.write = (chunk) => {
+    written = Buffer.concat([written, chunk])
+  }
+  mqtt.writeToStream.cacheNumbers = false
+
+  mqtt.writeToStream(message, stream)
+
+  t.deepEqual(written, expected, 'written buffer is expected')
+
+  mqtt.writeToStream.cacheNumbers = true
+
+  stream.end()
+  t.end()
+})
+
 testParseGenerate('minimal connect', {
   cmd: 'connect',
   retain: false,

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -41,6 +41,10 @@ function generate (packet, stream) {
       return false
   }
 }
+/**
+ * Controls numbers cache.
+ * Set to "false" to allocate buffers on-the-flight instead of pre-generated cache
+ */
 generate.cacheNumbers = true
 
 function uncork (stream) {

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -62,6 +62,7 @@ Object.defineProperty(generate, 'cacheNumbers', {
   },
   set: function (value) {
     if (value) {
+      if (!numCache || Object.keys(numCache).length === 0) toGenerate = true
       writeNumber = writeNumberCached
     } else {
       toGenerate = false

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -41,6 +41,7 @@ function generate (packet, stream) {
       return false
   }
 }
+generate.cacheNumbers = true
 
 function uncork (stream) {
   stream.uncork()
@@ -520,7 +521,7 @@ function writeString (stream, string) {
  * @api private
  */
 function writeNumber (stream, number) {
-  return stream.write(numCache[number])
+  return stream.write(numCache.get(number, generate.cacheNumbers))
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/mqttjs/mqtt-packet/issues/28

Add a flag `cacheNumbers` to control the numbers cache. Disabling the cache may save up to 14Mb of memory (node process).

Performance (`benchmarks/writeToStream.js`, average of 10 runs, Packet/s):
- before changes:                   386675.1239634539
- after changes (w/ cache):   376886.5427892937
- after changes (w/o cache): 353188.7654481942