### PR TITLE
Fix inverse logic when calculating payload length during publish

### DIFF
--- a/writeToStream.js
+++ b/writeToStream.js
@@ -272,7 +272,7 @@ function publish (opts, stream) {
   }
 
   // Get the payload length
-  if (!Buffer.isBuffer(payload)) length += Buffer.byteLength(payload)
+  if (Buffer.isBuffer(payload)) length += Buffer.byteLength(payload)
   else length += payload.length
 
   // Message ID must a number if qos > 0


### PR DESCRIPTION
I was getting weird errors in my application that uses mqtt and protobuf.
After some debugging, it turns out the size of the message I send is not correct.
Going through the code step by step I noticed the point of failure being mqtt-packet publish function.

You're using `Buffer.byteLength` when the payload is *not* a Buffer.
I believe this to be a typo. My application now works properly with the fix.