### PR TITLE
get ArrayBuffer payload length NaN

### DIFF
--- a/writeToStream.js
+++ b/writeToStream.js
@@ -320,8 +320,7 @@ function publish (packet, stream, opts) {
 
   // Get the payload length
   if (!Buffer.isBuffer(payload)) length += Buffer.byteLength(payload)
-  else length += payload.length
-
+  else length += payload.byteLength
   // Message ID must a number if qos > 0
   if (qos && typeof id !== 'number') {
     stream.emit('error', new Error('Invalid messageId'))


### PR DESCRIPTION
When I use MQTT.js in wechat and publish ArrayBuffer message，the subclient cannot recv the message.
I debugged the program and found get the ArrayBuffer payload length "payload.length" is undefined.
And in _stream_writable.js "write" method the payload encoding is converted to “utf-8”,not "buffer"。
I've made changes and passed the test in the project.