### PR TITLE
Fix return value of unsubscribe packet

### DIFF
--- a/test.js
+++ b/test.js
@@ -60,6 +60,16 @@ function testParseGenerate (name, object, buffer, opts) {
 
     t.equal(parser.parse(fixture), 0, 'remaining bytes')
   })
+
+  test(name + ' writeToStream', function (t) {
+    var stream = WS()
+    stream.write = () => true
+    stream.on('error', (err) => t.fail(err))
+
+    var result = mqtt.writeToStream(object, stream, opts)
+    t.equal(result, true, 'should return true')
+    t.end()
+  })
 }
 
 function testParseError (expected, fixture, opts) {

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -617,12 +617,11 @@ function unsubscribe (packet, stream, opts) {
   }
 
   // Unsubs
-  var result = true
   for (var j = 0; j < unsubs.length; j++) {
-    result = writeString(stream, unsubs[j])
+    writeString(stream, unsubs[j])
   }
 
-  return result
+  return true
 }
 
 function unsuback (packet, stream, opts) {

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -617,11 +617,12 @@ function unsubscribe (packet, stream, opts) {
   }
 
   // Unsubs
+  var result = true
   for (var j = 0; j < unsubs.length; j++) {
-    writeString(stream, unsubs[j])
+    result = writeString(stream, unsubs[j])
   }
 
-  return true
+  return result
 }
 
 function unsuback (packet, stream, opts) {

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -794,7 +794,7 @@ function writeString (stream, string) {
   var strlen = Buffer.byteLength(string)
   writeNumber(stream, strlen)
 
-  stream.write(string, 'utf8')
+  return stream.write(string, 'utf8')
 }
 
 /**


### PR DESCRIPTION
This method returned `undefined` even though others returned truthy value.
(`writeString` method doesn't have return value.)

Depending on how it was used, there was an issue in stream processing in my application.

<s>P.S. I'm not sure which is the correct return value type of `generate` method:`boolean` or `number`. I chose boolean followed by other methods.</s>

Thanks!

(edited): 

The return value is used in `mqtt-connection/lib/writeToStream.js`.
https://github.com/mqttjs/mqtt-connection/blob/master/lib/writeToStream.js#L13

I guess this method expects a return value of `writeToStream()` is a return value of `stream.write()`
