### PR TITLE
fix: mqtt5 disconnect can have no property fields

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -443,10 +443,13 @@ Parser.prototype._parseDisconnect = function () {
   if (this.settings.protocolVersion === 5) {
     // response code
     packet.reasonCode = this._parseByte()
+
     // properies mqtt 5
-    var properties = this._parseProperties()
-    if (Object.getOwnPropertyNames(properties).length) {
-      packet.properties = properties
+    if (packet.length > 1) {
+      var properties = this._parseProperties()
+      if (Object.getOwnPropertyNames(properties).length) {
+        packet.properties = properties
+      }
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -1551,6 +1551,18 @@ testParseGenerate('disconnect MQTT 5', {
   28, 0, 4, 116, 101, 115, 116// serverReference
 ]), {protocolVersion: 5})
 
+testParseGenerate('disconnect MQTT 5 with no properties', {
+  cmd: 'disconnect',
+  retain: false,
+  qos: 0,
+  dup: false,
+  length: 1,
+  reasonCode: 0
+}, Buffer.from([
+  224, 1, // Header
+  0 // reason code
+]), {protocolVersion: 5})
+
 testParseGenerate('auth MQTT 5', {
   cmd: 'auth',
   retain: false,

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -716,7 +716,7 @@ function disconnect (packet, stream, opts) {
 
   // properies mqtt 5
   var propertiesData = null
-  if (version === 5) {
+  if (version === 5 && properties) {
     propertiesData = getPropertiesByMaximumPacketSize(stream, properties, opts, length)
     if (!propertiesData) { return false }
     length += propertiesData.length


### PR DESCRIPTION
> MQTT v5, Section 3.14.2.1 , Line 2562
> The length of Properties in the DISCONNECT packet Variable Header encoded as a Variable Byte Integer. If the Remaining Length is less than 2, a value of 0 is used.

If a server send a disconnect packet without properties, the parser will access buffer out of bound. 