### PR TITLE
Use null prototype for userProperties

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -627,7 +627,7 @@ class Parser extends EventEmitter {
       // user properties process
       if (name === 'userProperties') {
         if (!result[name]) {
-          result[name] = {}
+          result[name] = Object.create(null)
         }
         const currentUserProperty = this._parseByType(constants.propertiesTypes[name])
         if (result[name][currentUserProperty.name]) {

--- a/test.js
+++ b/test.js
@@ -2064,3 +2064,60 @@ testWriteToStreamError('Invalid messageId', {
   cmd: 'subscribe',
   mid: {}
 })
+
+test('userProperties null prototype', t => {
+  t.plan(3)
+
+  const packet = mqtt.generate({
+    cmd: 'connect',
+    retain: false,
+    qos: 0,
+    dup: false,
+    length: 125,
+    protocolId: 'MQTT',
+    protocolVersion: 5,
+    will: {
+      retain: true,
+      qos: 2,
+      properties: {
+        willDelayInterval: 1234,
+        payloadFormatIndicator: false,
+        messageExpiryInterval: 4321,
+        contentType: 'test',
+        responseTopic: 'topic',
+        correlationData: Buffer.from([1, 2, 3, 4]),
+        userProperties: {
+          test: 'test'
+        }
+      },
+      topic: 'topic',
+      payload: Buffer.from([4, 3, 2, 1])
+    },
+    clean: true,
+    keepalive: 30,
+    properties: {
+      sessionExpiryInterval: 1234,
+      receiveMaximum: 432,
+      maximumPacketSize: 100,
+      topicAliasMaximum: 456,
+      requestResponseInformation: true,
+      requestProblemInformation: true,
+      userProperties: {
+        test: 'test'
+      },
+      authenticationMethod: 'test',
+      authenticationData: Buffer.from([1, 2, 3, 4])
+    },
+    clientId: 'test'
+  })
+
+  const parser = mqtt.parser()
+
+  parser.on('packet', packet => {
+    t.equal(packet.cmd, 'connect')
+    t.equal(Object.getPrototypeOf(packet.properties.userProperties), null)
+    t.equal(Object.getPrototypeOf(packet.will.properties.userProperties), null)
+  })
+
+  parser.parse(packet)
+})


### PR DESCRIPTION
It is a good security practice to set the prototype to null to avoid
adding methods such as hasOwnProperties that users could actually call.
Calling those methods directly might lead to a crash or an error.

See: https://github.com/nodejs/node/blob/e1edd6bbfab32bf95ee33532f1d4faaeafceb13c/lib/querystring.js#L262