### PR TITLE
Fix: restrict Variable Byte Integer to 24bits

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -37,8 +37,8 @@ protocol.QOS_SHIFT = 1
 protocol.RETAIN_MASK = 0x01
 
 /* Length */
-protocol.LENGTH_MASK = 0x7F
-protocol.LENGTH_FIN_MASK = 0x80
+protocol.VARBYTEINT_MASK = 0x7F
+protocol.VARBYTEINT_FIN_MASK = 0x80
 
 /* Connack */
 protocol.SESSIONPRESENT_MASK = 0x01

--- a/numbers.js
+++ b/numbers.js
@@ -1,6 +1,13 @@
 const max = 65536
 const cache = {}
 
+// in node 6 Buffer.subarray returns a Uint8Array instead of a Buffer
+// later versions return a Buffer
+// alternative is Buffer.slice but that creates a new buffer
+// creating new buffers takes time
+// SubOk is only false on node < 8
+const SubOk = Buffer.isBuffer(Buffer.from([1, 2]).subarray(0, 1))
+
 function generateBuffer (i) {
   const buffer = Buffer.allocUnsafe(2)
   buffer.writeUInt8(i >> 8, 0)
@@ -33,7 +40,7 @@ function genBufVariableByteInt (num) {
     pos = 0
   }
 
-  return buffer.subarray(0, pos)
+  return SubOk ? buffer.subarray(0, pos) : buffer.slice(0, pos)
 }
 
 function generate4ByteBuffer (num) {

--- a/numbers.js
+++ b/numbers.js
@@ -15,25 +15,11 @@ function generateCache () {
   }
 }
 
-/**
- * calcVariableByteIntLength - calculate the variable byte integer
- * length field
- *
- * @api private
- */
-function calcVariableByteIntLength (length) {
-  if (length >= 0 && length < 128) return 1
-  else if (length >= 128 && length < 16384) return 2
-  else if (length >= 16384 && length < 2097152) return 3
-  else if (length >= 2097152 && length < 268435456) return 4
-  else return 0
-}
-
 function genBufVariableByteInt (num) {
+  const maxLength = 4 // max 4 bytes
   let digit = 0
   let pos = 0
-  const length = calcVariableByteIntLength(num)
-  const buffer = Buffer.allocUnsafe(length)
+  const buffer = Buffer.allocUnsafe(maxLength)
 
   do {
     digit = num % 128 | 0
@@ -41,12 +27,13 @@ function genBufVariableByteInt (num) {
     if (num > 0) digit = digit | 0x80
 
     buffer.writeUInt8(digit, pos++)
-  } while (num > 0)
+  } while (num > 0 && pos < maxLength)
 
-  return {
-    data: buffer,
-    length
+  if (num > 0) {
+    pos = 0
   }
+
+  return buffer.subarray(0, pos)
 }
 
 function generate4ByteBuffer (num) {

--- a/test.js
+++ b/test.js
@@ -205,6 +205,9 @@ test('disabled numbers cache', t => {
 testGenerateError('Unknown command', {})
 
 testParseError('Not supported', Buffer.from([0, 1, 0]), {})
+testParseError('Invalid length', Buffer.from(
+  [16, 255, 255, 255, 255]
+), {})
 
 testParseGenerate('minimal connect', {
   cmd: 'connect',
@@ -1246,6 +1249,21 @@ test('splitted publish parse', t => {
     116, 101, 115, 116 // Payload (test)
   ])), 0, 'remaining bytes')
 })
+
+testGenerateError('Invalid subscriptionIdentifier: 268435456', {
+  cmd: 'publish',
+  retain: true,
+  qos: 2,
+  dup: true,
+  length: 27,
+  topic: 'test',
+  payload: Buffer.from('test'),
+  messageId: 10,
+  properties: {
+    payloadFormatIndicator: false,
+    subscriptionIdentifier: 268435456
+  }
+}, { protocolVersion: 5 }, 'MQTT 5.0 var byte integer >24 bits throws error')
 
 testParseGenerate('puback', {
   cmd: 'puback',

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -783,7 +783,7 @@ function writeVarByteInt (stream, num) {
   let buffer = varByteIntCache[num]
 
   if (!buffer) {
-    buffer = genBufVariableByteInt(num).data
+    buffer = genBufVariableByteInt(num)
     if (num < 16384) varByteIntCache[num] = buffer
   }
   debug('writeVarByteInt: writing to stream: %o', buffer)
@@ -922,11 +922,12 @@ function getProperties (stream, properties) {
         break
       }
       case 'var': {
-        if (typeof value !== 'number' || value < 0 || value > 0xffffffff) {
+        // var byte integer is max 24 bits packed in 32 bits
+        if (typeof value !== 'number' || value < 0 || value > 0x0fffffff) {
           stream.emit('error', new Error(`Invalid ${name}: ${value}`))
           return false
         }
-        length += 1 + genBufVariableByteInt(value).length
+        length += 1 + Buffer.byteLength(genBufVariableByteInt(value))
         break
       }
       case 'string': {
@@ -983,7 +984,7 @@ function getProperties (stream, properties) {
       propertiesLength += propLength
     }
   }
-  const propertiesLengthLength = genBufVariableByteInt(propertiesLength).length
+  const propertiesLengthLength = Buffer.byteLength(genBufVariableByteInt(propertiesLength))
 
   return {
     length: propertiesLengthLength + propertiesLength,


### PR DESCRIPTION
The MQTT 5.0 specification defines [Variable Byte Integer](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901011)  as a maximum of 24 bits. The 3.x  spec uses this format for packet length only but in 5.0 it is also used in properties (e.g. [subscriptionIdentifier](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901117))

Testing _generation_ of a Variable Byte Integer with anything bigger than that resulted in a  `Attempt to write outside buffer bounds` error because numbers.js would allocate 0 bytes and still try to write 4 or more bytes.
_Parsing_ of a Variable Byte Integer (e.g. in packet length) > 24 bits would not emit an error where it should.

This PR fixes that and adds tests to confirm 24 bits maximum.

It also renames the constants and variables used by the parser so they are inline with its intended use again.

Performance should not be impacted because:
a)  generator algorithm has been simplified so it should be a tiny bit faster
b)  the cache hides the performance of generation anyway :-)
c)  the rest of the changes are only small logic updates

Kind regards,
Hans




