### PR TITLE
Fix: error handling for Variable Byte Integer #95

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -39,6 +39,7 @@ protocol.RETAIN_MASK = 0x01
 /* Length */
 protocol.VARBYTEINT_MASK = 0x7F
 protocol.VARBYTEINT_FIN_MASK = 0x80
+protocol.VARBYTEINT_MAX = 268435455
 
 /* Connack */
 protocol.SESSIONPRESENT_MASK = 0x01

--- a/test.js
+++ b/test.js
@@ -1283,6 +1283,16 @@ test('splitted publish parse', t => {
   ])), 0, 'remaining bytes')
 })
 
+testGenerateError('Invalid length: 268435456', {
+  cmd: 'publish',
+  retain: false,
+  qos: 0,
+  dup: false,
+  length: (268435455 + 1),
+  topic: 'test',
+  payload: Buffer.alloc(268435455 + 1 - 6)
+}, {}, 'Length var byte integer over max allowed value throws error')
+
 testGenerateError('Invalid subscriptionIdentifier: 268435456', {
   cmd: 'publish',
   retain: true,

--- a/test.js
+++ b/test.js
@@ -207,10 +207,10 @@ testGenerateError('Unknown command', {})
 testParseError('Not supported', Buffer.from([0, 1, 0]), {})
 
 // Length header field
-testParseError('Invalid length', Buffer.from(
+testParseError('Invalid variable byte integer', Buffer.from(
   [16, 255, 255, 255, 255]
 ), {})
-testParseError('Invalid length', Buffer.from(
+testParseError('Invalid variable byte integer', Buffer.from(
   [16, 255, 255, 255, 128]
 ), {})
 
@@ -1352,7 +1352,7 @@ test('split length parse', t => {
     0, 'remaining bytes')
 })
 
-testGenerateError('Invalid length: 268435456', {
+testGenerateError('Invalid variable byte integer: 268435456', {
   cmd: 'publish',
   retain: false,
   qos: 0,

--- a/test.js
+++ b/test.js
@@ -232,6 +232,18 @@ testParseError('Invalid variable byte integer', Buffer.from(
 testParseError('Invalid variable byte integer', Buffer.from(
   [16, 255, 255, 255, 128]
 ), {})
+testParseError('Invalid variable byte integer', Buffer.from(
+  [16, 255, 255, 255, 255, 1]
+), {})
+testParseError('Invalid variable byte integer', Buffer.from(
+  [16, 255, 255, 255, 255, 127]
+), {})
+testParseError('Invalid variable byte integer', Buffer.from(
+  [16, 255, 255, 255, 255, 128]
+), {})
+testParseError('Invalid variable byte integer', Buffer.from(
+  [16, 255, 255, 255, 255, 255, 1]
+), {})
 
 testParseGenerate('minimal connect', {
   cmd: 'connect',

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -780,6 +780,11 @@ function auth (packet, stream, opts) {
 
 const varByteIntCache = {}
 function writeVarByteInt (stream, num) {
+  if (num > protocol.VARBYTEINT_MAX) {
+    stream.emit('error', new Error(`Invalid variable byte integer: ${num}`))
+    return false
+  }
+
   let buffer = varByteIntCache[num]
 
   if (!buffer) {
@@ -787,7 +792,7 @@ function writeVarByteInt (stream, num) {
     if (num < 16384) varByteIntCache[num] = buffer
   }
   debug('writeVarByteInt: writing to stream: %o', buffer)
-  stream.write(buffer)
+  return stream.write(buffer)
 }
 
 /**


### PR DESCRIPTION
This fixes the regression outlined in #95 which was introduced by #90 .
See #95 for more specific details of the primary problem being addressed here.

Changes:

- Avoid emitting false errors when not all bytes are present yet when parsing the variable byte integer for the length header.
- Emit error upon attempting to generate a variable byte integer beyond the maximum allowed size.
- Add more test coverage in this area.
