### PR TITLE
Fix Buffer Out of Bounds Error

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -548,7 +548,7 @@ class Parser extends EventEmitter {
     let current
     const padding = this._pos ? this._pos : 0
 
-    while (bytes < maxBytes) {
+    while (bytes < maxBytes && (padding + bytes) < this._list.length) {
       current = this._list.readUInt8(padding + bytes++)
       value += mul * (current & constants.VARBYTEINT_MASK)
       mul *= 0x80

--- a/test.js
+++ b/test.js
@@ -158,7 +158,12 @@ function testGenerateErrorMultipleCmds (cmds, expected, fixture, opts) {
   )
 }
 
-function testParseGenerateDefaults (name, object, buffer, opts) {
+function testParseGenerateDefaults (name, object, buffer, generated, opts) {
+  testParseOnly(`${name} parse`, generated, buffer, opts)
+  testGenerateOnly(`${name} generate`, object, buffer, opts)
+}
+
+function testParseAndGenerate (name, object, buffer, opts) {
   testParseOnly(`${name} parse`, object, buffer, opts)
   testGenerateOnly(`${name} generate`, object, buffer, opts)
 }
@@ -516,6 +521,13 @@ testParseGenerate('no clientId with 3.1.1', {
 
 testParseGenerateDefaults('default connect', {
   cmd: 'connect',
+  clientId: 'test'
+}, Buffer.from([
+  16, 16, 0, 4, 77, 81, 84,
+  84, 4, 2, 0, 0,
+  0, 4, 116, 101, 115, 116
+]), {
+  cmd: 'connect',
   retain: false,
   qos: 0,
   dup: false,
@@ -527,13 +539,9 @@ testParseGenerateDefaults('default connect', {
   clean: true,
   keepalive: 0,
   clientId: 'test'
-}, Buffer.from([
-  16, 16, 0, 4, 77, 81, 84,
-  84, 4, 2, 0, 0,
-  0, 4, 116, 101, 115, 116
-]))
+})
 
-testParseGenerateDefaults('Version 4 CONACK', {
+testParseAndGenerate('Version 4 CONACK', {
   cmd: 'connack',
   retain: false,
   qos: 0,
@@ -548,7 +556,7 @@ testParseGenerateDefaults('Version 4 CONACK', {
   0, 1 // Variable Header (Session not present, Connection Refused - unacceptable protocol version)
 ]), {}) // Default protocolVersion (4)
 
-testParseGenerateDefaults('Version 5 CONACK', {
+testParseAndGenerate('Version 5 CONACK', {
   cmd: 'connack',
   retain: false,
   qos: 0,


### PR DESCRIPTION
Fix bug in _parseVarByteNum() function causing Buffer Out of Bounds Error.

Added Tests.

Also refactored the testParseGenerateDefaults() test function to separate out a new testParseOnly() which can be used directly.

Fixes #99, fixes #98, closes #78, fixes mqttjs/MQTT.js#1073, fixes mqttjs/MQTT.js#993, fixes mqttjs/MQTT.js#1176

Possible fix to mqttjs/MQTT.js#1228 which has this function in the call stack. Unfortunately no specific test provided in that issue to prove it's fixed.

Probable fix to #72, but gist and test not longer present to check it.