### PR TITLE
fix to allow zero length client identifiers in MQTT v5.0

### DIFF
--- a/test.js
+++ b/test.js
@@ -519,6 +519,37 @@ testParseGenerate('no clientId with 3.1.1', {
   0, 0 // Client ID length
 ]))
 
+testParseGenerateDefaults('no clientId with 5.0', {
+  cmd: 'connect',
+  protocolId: 'MQTT',
+  protocolVersion: 5,
+  clean: true,
+  keepalive: 60,
+  properties:
+    {
+      receiveMaximum: 20
+    },
+  clientId: ''
+}, Buffer.from(
+  [16, 16, 0, 4, 77, 81, 84, 84, 5, 2, 0, 60, 3, 33, 0, 20, 0, 0]
+), {
+  cmd: 'connect',
+  retain: false,
+  qos: 0,
+  dup: false,
+  length: 16,
+  topic: null,
+  payload: null,
+  protocolId: 'MQTT',
+  protocolVersion: 5,
+  clean: true,
+  keepalive: 60,
+  properties: {
+    receiveMaximum: 20
+  },
+  clientId: ''
+}, { protocolVersion: 5 })
+
 testParseGenerateDefaults('default connect', {
   cmd: 'connect',
   clientId: 'test'

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -110,9 +110,9 @@ function connect (packet, stream, opts) {
     return false
   } else length += 1
 
-  // ClientId might be omitted in 3.1.1, but only if cleanSession is set to 1
+  // ClientId might be omitted in 3.1.1 and 5, but only if cleanSession is set to 1
   if ((typeof clientId === 'string' || Buffer.isBuffer(clientId)) &&
-     (clientId || protocolVersion === 4) && (clientId || clean)) {
+     (clientId || protocolVersion >= 4) && (clientId || clean)) {
     length += clientId.length + 2
   } else {
     if (protocolVersion < 4) {


### PR DESCRIPTION
Same as PR #71 but includes the requested test

closes #71 fixes #68