### PR TITLE
Add support for mosquitto bridge versions 131 and 132

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -171,6 +171,8 @@ protocol.SUBACK_HEADER = Buffer.from([protocol.codes.suback << protocol.CMD_SHIF
 protocol.VERSION3 = Buffer.from([3])
 protocol.VERSION4 = Buffer.from([4])
 protocol.VERSION5 = Buffer.from([5])
+protocol.VERSION131 = Buffer.from([131])
+protocol.VERSION132 = Buffer.from([132])
 
 /* QoS */
 protocol.QOS = [0, 1, 2].map(qos => {

--- a/parser.js
+++ b/parser.js
@@ -158,6 +158,11 @@ class Parser extends EventEmitter {
 
     packet.protocolVersion = this._list.readUInt8(this._pos)
 
+    if (packet.protocolVersion === 131 || packet.protocolVersion === 132) {
+      packet.bridgeVersion = packet.protocolVersion
+      packet.protocolVersion = 3
+    }
+
     if (packet.protocolVersion !== 3 && packet.protocolVersion !== 4 && packet.protocolVersion !== 5) {
       return this._emitError(new Error('Invalid protocol version'))
     }
@@ -337,6 +342,10 @@ class Parser extends EventEmitter {
         subscription.nl = nl
         subscription.rap = rap
         subscription.rh = rh
+      } else if (this.settings.bridgeVersion) {
+        subscription.rh = 0
+        subscription.rap = true
+        subscription.nl = true
       }
 
       // Push pair to subscriptions

--- a/parser.js
+++ b/parser.js
@@ -158,9 +158,9 @@ class Parser extends EventEmitter {
 
     packet.protocolVersion = this._list.readUInt8(this._pos)
 
-    if (packet.protocolVersion === 131 || packet.protocolVersion === 132) {
-      packet.bridgeVersion = packet.protocolVersion
-      packet.protocolVersion = 3
+    if (packet.protocolVersion >= 128) {
+      packet.bridgeMode = true
+      packet.protocolVersion = packet.protocolVersion - 128
     }
 
     if (packet.protocolVersion !== 3 && packet.protocolVersion !== 4 && packet.protocolVersion !== 5) {
@@ -342,7 +342,7 @@ class Parser extends EventEmitter {
         subscription.nl = nl
         subscription.rap = rap
         subscription.rh = rh
-      } else if (this.settings.bridgeVersion) {
+      } else if (this.settings.bridgeMode) {
         subscription.rh = 0
         subscription.rap = true
         subscription.nl = true

--- a/test.js
+++ b/test.js
@@ -295,6 +295,52 @@ testGenerateOnly('minimal connect with clientId as Buffer', {
   116, 101, 115, 116 // Client ID
 ]))
 
+testParseGenerate('connect MQTT bridge 131', {
+  cmd: 'connect',
+  retain: false,
+  qos: 0,
+  dup: false,
+  length: 18,
+  protocolId: 'MQIsdp',
+  protocolVersion: 3,
+  bridgeVersion: 131,
+  clean: false,
+  keepalive: 30,
+  clientId: 'test'
+}, Buffer.from([
+  16, 18, // Header
+  0, 6, // Protocol ID length
+  77, 81, 73, 115, 100, 112, // Protocol ID
+  131, // Protocol version
+  0, // Connect flags
+  0, 30, // Keepalive
+  0, 4, // Client ID length
+  116, 101, 115, 116 // Client ID
+]))
+
+testParseGenerate('connect MQTT bridge 132', {
+  cmd: 'connect',
+  retain: false,
+  qos: 0,
+  dup: false,
+  length: 18,
+  protocolId: 'MQIsdp',
+  protocolVersion: 3,
+  bridgeVersion: 132,
+  clean: false,
+  keepalive: 30,
+  clientId: 'test'
+}, Buffer.from([
+  16, 18, // Header
+  0, 6, // Protocol ID length
+  77, 81, 73, 115, 100, 112, // Protocol ID
+  132, // Protocol version
+  0, // Connect flags
+  0, 30, // Keepalive
+  0, 4, // Client ID length
+  116, 101, 115, 116 // Client ID
+]))
+
 testParseGenerate('connect MQTT 5', {
   cmd: 'connect',
   retain: false,

--- a/test.js
+++ b/test.js
@@ -303,7 +303,7 @@ testParseGenerate('connect MQTT bridge 131', {
   length: 18,
   protocolId: 'MQIsdp',
   protocolVersion: 3,
-  bridgeVersion: 131,
+  bridgeMode: true,
   clean: false,
   keepalive: 30,
   clientId: 'test'
@@ -325,8 +325,8 @@ testParseGenerate('connect MQTT bridge 132', {
   dup: false,
   length: 18,
   protocolId: 'MQIsdp',
-  protocolVersion: 3,
-  bridgeVersion: 132,
+  protocolVersion: 4,
+  bridgeMode: true,
   clean: false,
   keepalive: 30,
   clientId: 'test'

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -83,7 +83,7 @@ function uncork (stream) {
 function connect (packet, stream, opts) {
   const settings = packet || {}
   const protocolId = settings.protocolId || 'MQTT'
-  const protocolVersion = settings.protocolVersion || 4
+  let protocolVersion = settings.protocolVersion || 4
   const will = settings.will
   let clean = settings.clean
   const keepalive = settings.keepalive || 0
@@ -217,12 +217,21 @@ function connect (packet, stream, opts) {
 
   // Generate protocol ID
   writeStringOrBuffer(stream, protocolId)
+
+  if (protocolVersion === 3 && settings.bridgeVersion) {
+    protocolVersion = settings.bridgeVersion
+  }
+
   stream.write(
-    protocolVersion === 4
-      ? protocol.VERSION4
-      : protocolVersion === 5
-        ? protocol.VERSION5
-        : protocol.VERSION3
+    protocolVersion === 131
+      ? protocol.VERSION131
+      : protocolVersion === 132
+        ? protocol.VERSION132
+        : protocolVersion === 4
+          ? protocol.VERSION4
+          : protocolVersion === 5
+            ? protocol.VERSION5
+            : protocol.VERSION3
   )
 
   // Connect flags

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -218,8 +218,8 @@ function connect (packet, stream, opts) {
   // Generate protocol ID
   writeStringOrBuffer(stream, protocolId)
 
-  if (protocolVersion === 3 && settings.bridgeVersion) {
-    protocolVersion = settings.bridgeVersion
+  if (settings.bridgeMode) {
+    protocolVersion += 128
   }
 
   stream.write(


### PR DESCRIPTION
These protocols are for bridge mode of version 3.  According to https://github.com/mqtt/mqtt.org/wiki/bridge_protocol these versions set the following properties:
- ras = true
- nl = true
