### PR TITLE
fix(connect packet types): payloadFormatIndicator

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,7 +54,7 @@ export interface IConnectPacket extends IPacket {
     retain?: boolean
     properties?: {
       willDelayInterval?: number,
-      payloadFormatIndicator?: number,
+      payloadFormatIndicator?: boolean,
       messageExpiryInterval?: number,
       contentType?: string,
       responseTopic?: string,


### PR DESCRIPTION
The connect packet type is shown as a boolean in examples, but the type is set as a number.