### PR TITLE
fix: buffer is not defined in browser

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,5 +1,6 @@
 /* Protocol - protocol constants */
 const protocol = module.exports
+const { Buffer } = require('buffer')
 
 /* Command code => mnemonic */
 protocol.types = {

--- a/generate.js
+++ b/generate.js
@@ -1,5 +1,6 @@
 const writeToStream = require('./writeToStream')
 const EventEmitter = require('events')
+const { Buffer } = require('buffer')
 
 function generate (packet, opts) {
   const stream = new Accumulator()

--- a/numbers.js
+++ b/numbers.js
@@ -1,3 +1,4 @@
+const { Buffer } = require('buffer')
 const max = 65536
 const cache = {}
 

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -1,4 +1,5 @@
 const protocol = require('./constants')
+const { Buffer } = require('buffer')
 const empty = Buffer.allocUnsafe(0)
 const zeroBuf = Buffer.from([0])
 const numbers = require('./numbers')


### PR DESCRIPTION
## Background
Buffer is an API in Node.js and does not exist in browsers. When upgrading to webpack 5, webpack will no longer automatically bundles core node modules (buffer/process etc.). Which will cause the `Buffer is not defined` problems.
https://github.com/mqttjs/MQTT.js/issues/1412
https://github.com/mqttjs/MQTT.js/issues/1338

## Solutions
1. Although we can add polyfills by modifying the `webpack.config.js` file. But there are also some scenarios where the `webpack.config.js` cannot be modified (such as the Openharmony development environment I‘m using).
2. The Node.js doc recommends to explicitly import or require 'buffer':
> While the Buffer class is available within the global scope, it is still recommended to explicitly reference it via an import or require statement.
https://nodejs.org/api/buffer.html
![image](https://user-images.githubusercontent.com/9528435/153153264-906a20b7-c836-42b8-b75f-fb3c54945ebf.png)
After that, just insall 'buffer' can fix this problem.
```
npm install buffer
```