### PR TITLE
Typescript updates: improve subscription identifier support

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -89,7 +89,7 @@ export interface IPublishPacket extends IPacket {
     responseTopic?: string,
     correlationData?: Buffer,
     userProperties?: UserProperties,
-    subscriptionIdentifier?: number,
+    subscriptionIdentifier?: number | [number],
     contentType?: string
   }
 }
@@ -133,6 +133,7 @@ export interface ISubscribePacket extends IPacket {
   subscriptions: ISubscription[],
   properties?: {
     reasonString?: string,
+    subscriptionIdentifier?: number,
     userProperties?: UserProperties
   }
 }


### PR DESCRIPTION
* adds subscriptionIdentifier definition to ISubscribePacket (https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901166).  Existing test verifying correctness: "subscribe to one topic by MQTT 5"
* adds array variant of subscriptionIdentifier to IPublishPacket.  Existing test verifying correctness: "publish MQTT 5 with multiple same properties"

