### PR TITLE
Subscription Identifier: Typescript array not typescript tuple

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -89,7 +89,7 @@ export interface IPublishPacket extends IPacket {
     responseTopic?: string,
     correlationData?: Buffer,
     userProperties?: UserProperties,
-    subscriptionIdentifier?: number | [number],
+    subscriptionIdentifier?: number | number[],
     contentType?: string
   }
 }


### PR DESCRIPTION
The previous two-line PR (https://github.com/mqttjs/mqtt-packet/pull/132) contained a mistake and specified a one-number tuple rather than an array of numbers.  Sorry about that.
