### PR TITLE
fix: PUBACK packet not compatible with RabbitMQ

### DIFF
--- a/test.js
+++ b/test.js
@@ -724,13 +724,29 @@ testParseAndGenerate('Version 5 PUBACK test 2', {
   retain: false,
   qos: 0,
   dup: false,
-  length: 4,
+  length: 2,
   topic: null,
   payload: null,
   reasonCode: 0
 }, Buffer.from([
-  64, 4, // Fixed Header (PUBACK, Remaining Length)
-  0, 42, 0, 0 // Variable Header (2 Bytes: Packet Identifier 42, Reason code: 0 Success, No properties: 0)
+  64, 2, // Fixed Header (PUBACK, Remaining Length)
+  0, 42 // Variable Header (2 Bytes: Packet Identifier 42, Implied reason code: 0 Success, Implied no properties)
+]), { protocolVersion: 5 }
+)
+
+testParseOnly('Version 5 PUBACK test 2.1', {
+  cmd: 'puback',
+  messageId: 42,
+  retain: false,
+  qos: 0,
+  dup: false,
+  length: 3,
+  topic: null,
+  payload: null,
+  reasonCode: 0
+}, Buffer.from([
+  64, 3, // Fixed Header (PUBACK, Remaining Length)
+  0, 42, 0 // Variable Header (2 Bytes: Packet Identifier 42, Reason code: 0 Success)
 ]), { protocolVersion: 5 }
 )
 
@@ -1867,6 +1883,19 @@ testParseError('Invalid header flag bits, must be 0x0 for puback packet', Buffer
   65, 2, // Header
   0, 2 // Message ID
 ]))
+
+testParseGenerate('puback without reason and no MQTT 5 properties', {
+  cmd: 'puback',
+  retain: false,
+  qos: 0,
+  dup: false,
+  length: 2,
+  messageId: 2,
+  reasonCode: 0
+}, Buffer.from([
+  64, 2, // Header
+  0, 2 // Message ID
+]), { protocolVersion: 5 })
 
 testParseGenerate('puback with reason and no MQTT 5 properties', {
   cmd: 'puback',

--- a/test.js
+++ b/test.js
@@ -746,7 +746,7 @@ testParseOnly('Version 5 PUBACK test 2.1', {
   reasonCode: 0
 }, Buffer.from([
   64, 3, // Fixed Header (PUBACK, Remaining Length)
-  0, 42, 0 // Variable Header (2 Bytes: Packet Identifier 42, Reason code: 0 Success)
+  0, 42, 0 // Variable Header (2 Bytes: Packet Identifier 42, Reason code: 0 Success, Implied no properties)
 ]), { protocolVersion: 5 }
 )
 

--- a/test.js
+++ b/test.js
@@ -724,13 +724,13 @@ testParseAndGenerate('Version 5 PUBACK test 2', {
   retain: false,
   qos: 0,
   dup: false,
-  length: 3,
+  length: 4,
   topic: null,
   payload: null,
   reasonCode: 0
 }, Buffer.from([
-  64, 3, // Fixed Header (PUBACK, Remaining Length)
-  0, 42, 0 // Variable Header (2 Bytes: Packet Identifier 42, Reason code: 0 Success, Implied no properties)
+  64, 4, // Fixed Header (PUBACK, Remaining Length)
+  0, 42, 0, 0 // Variable Header (2 Bytes: Packet Identifier 42, Reason code: 0 Success, No properties: 0)
 ]), { protocolVersion: 5 }
 )
 
@@ -1873,13 +1873,14 @@ testParseGenerate('puback with reason and no MQTT 5 properties', {
   retain: false,
   qos: 0,
   dup: false,
-  length: 3,
+  length: 4,
   messageId: 2,
   reasonCode: 16
 }, Buffer.from([
-  64, 3, // Header
+  64, 4, // Header
   0, 2, // Message ID
-  16 // reason code
+  16, // reason code
+  0 // no user properties
 ]), { protocolVersion: 5 })
 
 testParseGenerate('puback MQTT 5 properties', {

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -410,7 +410,8 @@ function confirmation (packet, stream, opts) {
   stream.write(protocol.ACKS[type][qos][dup][0])
 
   // Length
-  writeVarByteInt(stream, length === 3 ? 4 : length)
+  if (length === 3) length += 1
+  writeVarByteInt(stream, length)
 
   // Message ID
   writeNumber(stream, id)
@@ -424,7 +425,7 @@ function confirmation (packet, stream, opts) {
   if (propertiesData !== null) {
     propertiesData.write()
   } else {
-    if (length === 3) {
+    if (length === 4) {
       stream.write(Buffer.from([0]))
     }
   }

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -410,7 +410,7 @@ function confirmation (packet, stream, opts) {
   stream.write(protocol.ACKS[type][qos][dup][0])
 
   // Length
-  writeVarByteInt(stream, length)
+  writeVarByteInt(stream, length === 3 ? 4 : length)
 
   // Message ID
   writeNumber(stream, id)
@@ -423,6 +423,10 @@ function confirmation (packet, stream, opts) {
   // properies mqtt 5
   if (propertiesData !== null) {
     propertiesData.write()
+  } else {
+    if (length === 3) {
+      stream.write(Buffer.from([0]))
+    }
   }
   return true
 }

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -409,7 +409,6 @@ function confirmation (packet, stream, opts) {
   // Header
   stream.write(protocol.ACKS[type][qos][dup][0])
 
-  // Length
   // Length === 3 is only true of version === 5 and no properties; therefore if reasonCode === 0 we are allowed to skip both bytes - but if we write the reason code we also have to write property length [MQTT-3.4.2-1].
   if (length === 3) length += reasonCode !== 0 ? 1 : -1
   writeVarByteInt(stream, length)
@@ -417,7 +416,7 @@ function confirmation (packet, stream, opts) {
   // Message ID
   writeNumber(stream, id)
 
-  // reason code in header - but only if it couldn't be omitted - indicated by length !== 2 (implies version === and reason code === 0)
+  // reason code in header - but only if it couldn't be omitted - indicated by length !== 2.
   if (version === 5 && length !== 2) {
     stream.write(Buffer.from([reasonCode]))
   }
@@ -427,7 +426,7 @@ function confirmation (packet, stream, opts) {
     propertiesData.write()
   } else {
     if (length === 4) {
-      // if we have no properties but have written a reason code - so we need to indicate empty properties by filling in a zero.
+      // we have no properties but have written a reason code - so we need to indicate empty properties by filling in a zero.
       stream.write(Buffer.from([0]))
     }
   }

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -410,22 +410,24 @@ function confirmation (packet, stream, opts) {
   stream.write(protocol.ACKS[type][qos][dup][0])
 
   // Length
-  if (length === 3) length += 1
+  // Length === 3 is only true of version === 5 and no properties; therefore if reasonCode === 0 we are allowed to skip both bytes - but if we write the reason code we also have to write property length [MQTT-3.4.2-1].
+  if (length === 3) length += reasonCode !== 0 ? 1 : -1
   writeVarByteInt(stream, length)
 
   // Message ID
   writeNumber(stream, id)
 
-  // reason code in header
-  if (version === 5) {
+  // reason code in header - but only if it couldn't be omitted - indicated by length !== 2 (implies version === and reason code === 0)
+  if (version === 5 && length !== 2) {
     stream.write(Buffer.from([reasonCode]))
   }
 
-  // properies mqtt 5
+  // properties mqtt 5
   if (propertiesData !== null) {
     propertiesData.write()
   } else {
     if (length === 4) {
+      // if we have no properties but have written a reason code - so we need to indicate empty properties by filling in a zero.
       stream.write(Buffer.from([0]))
     }
   }


### PR DESCRIPTION
MQTT5 spec is not so clear about the possible remaining length of PUBACK pakets.

We have: 

- `If there are no properties, this MUST be indicated by including a Property Length of zero [MQTT-2.2.2-1]`.
This clearly allows us to have packets like [64, 4, 0 42, 0, 0] (puback, length:4, pakedId: 0 42, reason: 0, properties: 0]
- `The Client or Server sending the PUBACK packet MUST use one of the PUBACK Reason Codes [MQTT-3.4.2-1]. The Reason Code and Property Length can be omitted if the Reason Code is 0x00 (Success) and there are no Properties. In this case the PUBACK has a Remaining Length of 2.`
This allows packets like [64, 2, 0, 42]
- The discussion starts if it is valid to only have the reason byte without the properties length (due to the unclear statement in 
`3.4.2.2.1 Property Length
The length of the Properties in the PUBACK packet Variable Header encoded as a Variable Byte Integer.
If the Remaining Length is less than 4 there is no Property Length and the value of 0 is used.
` ) 
So basically - ist it valid to have [64, 3, 0, 42, 0]? I would argue no, the remaining length should be 2 or >= 4. So this patch strives to only generate packets with this remaining length. However we are still able to parse packets with a remaining length of 3.

To state my belief - if it were intended to be able to omit both bytes individually, it wouldn't makle sense limit this to reason code 0x00 - why should [64, 3, 0, 42, 0] be allowed, while [64, 3, 0, 42, 135] is not?

Fixes #92