### PR TITLE
fix: IUnsubackPacket types definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -163,7 +163,8 @@ export interface IUnsubackPacket extends IPacket {
   properties?: {
     reasonString?: string,
     userProperties?: UserProperties
-  }
+  },
+  granted: number[]
 }
 
 export interface IPubackPacket extends IPacket {


### PR DESCRIPTION
The implementation sets GRANTED in response to unsuback.

https://github.com/mqttjs/mqtt-packet/blob/ec5ad06d96192d8d9bcbe551c12df802aa38a33a/parser.js#L489


However, it is not present in the type definition of IUnsubackPacket.

https://github.com/mqttjs/mqtt-packet/blob/ec5ad06d96192d8d9bcbe551c12df802aa38a33a/types/index.d.ts#L160-L167

I made a PR, please check it out.