### PR TITLE
fix: correctly import `EventEmitter` to prevent errors with bundlers

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -1,5 +1,5 @@
 const writeToStream = require('./writeToStream')
-const EventEmitter = require('events')
+const { EventEmitter } = require('events')
 const { Buffer } = require('buffer')
 
 function generate (packet, opts) {

--- a/parser.js
+++ b/parser.js
@@ -1,5 +1,5 @@
 const bl = require('bl')
-const EventEmitter = require('events')
+const { EventEmitter } = require('events')
 const Packet = require('./packet')
 const constants = require('./constants')
 const debug = require('debug')('mqtt-packet:parser')


### PR DESCRIPTION
Importing EventEmitter like `const EventEmitter  = require('events')` creates errors with bundlers like esbuild, vite and so on: `TypeError: EventEmitter2 is not a constructor`