### PR TITLE
fix(conn): password can be set when username unset when mqttv5

### DIFF
--- a/writeToStream.js
+++ b/writeToStream.js
@@ -200,7 +200,7 @@ function connect (packet, stream, opts) {
 
   // Password
   if (password != null) {
-    if (!providedUsername) {
+    if (!providedUsername && protocolVersion !== 5) {
       stream.destroy(new Error('Username is required to use password'))
       return false
     }


### PR DESCRIPTION
see also:
> 3.1.2.8 User Name Flag
> Position: bit 7 of the Connect Flags.
>
>
>
> If the User Name Flag is set to 0, a User Name MUST NOT be present in the Payload [MQTT-3.1.2-16]. If the User Name Flag is set to 1, a User Name MUST be present in the Payload [MQTT-3.1.2-17].
>
>
>
> 3.1.2.9 Password Flag
> Position: bit 6 of the Connect Flags.
>
>
>
> If the Password Flag is set to 0, a Password MUST NOT be present in the Payload [MQTT-3.1.2-18]. If the Password Flag is set to 1, a Password MUST be present in the Payload [MQTT-3.1.2-19].
>
>
>
> Non-normative comment
>
> This version of the protocol allows the __sending of a Password with no User Name__, where MQTT v3.1.1 did not. This reflects the common use of Password for credentials other than a password.


https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901044