### PR TITLE
Protocol error on example Maximum QoS (CONNACK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ automatically be converted into a `Buffer`.
   properties: { // MQTT 5.0 properties
       sessionExpiryInterval: 1234,
       receiveMaximum: 432,
-      maximumQoS: 2,
+      maximumQoS: 1,
       retainAvailable: true,
       maximumPacketSize: 100,
       assignedClientIdentifier: 'test',


### PR DESCRIPTION
Quoting from the [Spec](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html):

> It is a Protocol Error to include Maximum QoS more than once, or to have a value other than 0 or 1. 

---

3.2.2.3.4 Maximum QoS

36 (0x24) Byte, Identifier of the Maximum QoS.
Followed by a Byte with a value of either 0 or 1. It is a Protocol Error to include Maximum QoS more than once, or to have a value other than 0 or 1. If the Maximum QoS is absent, the Client uses a Maximum QoS of 2.
 
If a Server does not support QoS 1 or QoS 2 PUBLISH packets it MUST send a Maximum QoS in the CONNACK packet specifying the highest QoS it supports [MQTT-3.2.2-9]. A Server that does not support QoS 1 or QoS 2 PUBLISH packets MUST still accept SUBSCRIBE packets containing a Requested QoS of 0, 1 or 2 [MQTT-3.2.2-10].
 
If a Client receives a Maximum QoS from a Server, it MUST NOT send PUBLISH packets at a QoS level exceeding the Maximum QoS level specified [MQTT-3.2.2-11]. It is a Protocol Error if the Server receives a PUBLISH packet with a QoS greater than the Maximum QoS it specified. In this case use DISCONNECT with Reason Code 0x9B (QoS not supported) as described in [section 4.13](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#S4_13_Errors) Handling errors.
 
If a Server receives a CONNECT packet containing a Will QoS that exceeds its capabilities, it MUST reject the connection. It SHOULD use a CONNACK packet with Reason Code 0x9B (QoS not supported) as described in [section 4.13](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#S4_13_Errors) Handling errors, and MUST close the Network Connection [MQTT-3.2.2-12].
 
Non-normative comment
A Client does not need to support QoS 1 or QoS 2 PUBLISH packets. If this is the case, the Client simply restricts the maximum QoS field in any SUBSCRIBE commands it sends to a value it can support.