### PR TITLE
fix(write): ignore undefined properties

### DIFF
--- a/test.js
+++ b/test.js
@@ -3068,7 +3068,6 @@ test('userProperties null prototype', t => {
       topicAliasMaximum: 456,
       requestResponseInformation: true,
       requestProblemInformation: true,
-      correlationData: undefined,
       userProperties: {
         test: 'test'
       },
@@ -3160,6 +3159,63 @@ test('stops parsing after first error', t => {
 
     224, 0 // Header
   ]))
+})
+
+test('undefined properties', t => {
+  t.plan(2)
+
+  const packet = mqtt.generate({
+    cmd: 'connect',
+    retain: false,
+    qos: 0,
+    dup: false,
+    length: 125,
+    protocolId: 'MQTT',
+    protocolVersion: 5,
+    will: {
+      retain: true,
+      qos: 2,
+      properties: {
+        willDelayInterval: 1234,
+        payloadFormatIndicator: false,
+        messageExpiryInterval: 4321,
+        contentType: 'test',
+        responseTopic: 'topic',
+        correlationData: Buffer.from([1, 2, 3, 4]),
+        userProperties: {
+          test: 'test'
+        }
+      },
+      topic: 'topic',
+      payload: Buffer.from([4, 3, 2, 1])
+    },
+    clean: true,
+    keepalive: 30,
+    properties: {
+      sessionExpiryInterval: 1234,
+      receiveMaximum: 432,
+      maximumPacketSize: 100,
+      topicAliasMaximum: 456,
+      requestResponseInformation: true,
+      requestProblemInformation: true,
+      correlationData: undefined,
+      userProperties: {
+        test: 'test'
+      },
+      authenticationMethod: 'test',
+      authenticationData: Buffer.from([1, 2, 3, 4])
+    },
+    clientId: 'test'
+  })
+
+  const parser = mqtt.parser()
+
+  parser.on('packet', packet => {
+    t.equal(packet.cmd, 'connect')
+    t.equal(Object.hasOwn(packet.properties, 'correlationData'), false)
+  })
+
+  parser.parse(packet)
 })
 
 testGenerateErrorMultipleCmds([

--- a/test.js
+++ b/test.js
@@ -3068,6 +3068,7 @@ test('userProperties null prototype', t => {
       topicAliasMaximum: 456,
       requestResponseInformation: true,
       requestProblemInformation: true,
+      correlationData: undefined,
       userProperties: {
         test: 'test'
       },

--- a/writeToStream.js
+++ b/writeToStream.js
@@ -993,7 +993,9 @@ function getProperties (stream, properties) {
       let propLength = 0
       let propValueLength = 0
       const propValue = properties[propName]
-      if (Array.isArray(propValue)) {
+      if (propValue === undefined) {
+        continue
+      } else if (Array.isArray(propValue)) {
         for (let valueIndex = 0; valueIndex < propValue.length; valueIndex++) {
           propValueLength = getLengthProperty(propName, propValue[valueIndex])
           if (!propValueLength) { return false }
@@ -1101,7 +1103,7 @@ function writeProperties (stream, properties, propertiesLength) {
   /* write properties to stream */
   writeVarByteInt(stream, propertiesLength)
   for (const propName in properties) {
-    if (Object.prototype.hasOwnProperty.call(properties, propName) && properties[propName] !== null) {
+    if (Object.prototype.hasOwnProperty.call(properties, propName) && properties[propName] != null) {
       const value = properties[propName]
       if (Array.isArray(value)) {
         for (let valueIndex = 0; valueIndex < value.length; valueIndex++) {


### PR DESCRIPTION
Closes #152.

Ignore any properties that are `undefined`. Note that it's not possible (by design) to ignore `undefined` in `getLengthProperty()` since returning `0` would result in destroying the stream.