### PR TITLE
feat: allow bridge protocol versions in packet generation

### DIFF
--- a/writeToStream.js
+++ b/writeToStream.js
@@ -105,8 +105,9 @@ function connect (packet, stream, opts) {
     return false
   } else length += protocolId.length + 2
 
-  // Must be 3 or 4 or 5
-  if (protocolVersion !== 3 && protocolVersion !== 4 && protocolVersion !== 5) {
+  // Must be 3 or 4 or 5 (+128 for bridge functionality)
+  const maskedVersion = protocolVersion < 128 ? protocolVersion : protocolVersion - 128
+  if (maskedVersion !== 3 && maskedVersion !== 4 && maskedVersion !== 5) {
     stream.destroy(new Error('Invalid protocol version'))
     return false
   } else length += 1


### PR DESCRIPTION
This PR allows bride protocol versions (MQTT protocol+128) to be generated as discussed in https://github.com/moscajs/aedes/pull/1042#pullrequestreview-3070159033

