### PR TITLE
fix: parse a minimal Success AUTH packet (Remaining Length 0)

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -569,9 +569,13 @@ class Parser extends EventEmitter {
     }
 
     // response code
-    packet.reasonCode = this._parseByte()
-    if (!constants.MQTT5_AUTH_CODES[packet.reasonCode]) {
-      return this._emitError(new Error('Invalid auth reason code'))
+    if (this._list.length > 0) {
+      packet.reasonCode = this._parseByte()
+      if (!constants.MQTT5_AUTH_CODES[packet.reasonCode]) {
+        return this._emitError(new Error('Invalid auth reason code'))
+      }
+    } else {
+      packet.reasonCode = 0
     }
     // properies mqtt 5
     const properties = this._parseProperties()

--- a/test.js
+++ b/test.js
@@ -2576,6 +2576,19 @@ testParseError('Invalid auth reason code', Buffer.from([
   0 // Property Length (0 => No Properties)
 ]), { protocolVersion: 5 })
 
+testParseOnly('minimal Success AUTH with reason code and property length omitted', {
+  cmd: 'auth',
+  retain: false,
+  qos: 0,
+  dup: false,
+  length: 0,
+  topic: null,
+  payload: null,
+  reasonCode: 0
+}, Buffer.from([
+  240, 0 // Fixed Header (AUTH, Remaining Length 0)
+]), { protocolVersion: 5 })
+
 testGenerateError('Invalid protocolId', {
   cmd: 'connect',
   retain: false,


### PR DESCRIPTION
MQTT 5.0 §3.15.2.2.1 says the AUTH Reason Code and Property Length **can be omitted** when the Reason Code is `0x00` (Success) and there are no Properties — giving an AUTH packet with Remaining Length 0, i.e. the two bytes `f0 00`. The re-authentication flow (§4.12) ends with the server sending such a Success AUTH, which a compliant peer may encode in this minimal form.

The parser rejects it:

```js
const parser = mqtt.parser({ protocolVersion: 5 })
parser.on('error', e => console.log(e.message))
parser.parse(Buffer.from([0xf0, 0x00]))
// => "Invalid auth reason code"
```

### Cause
`_parseAuth()` reads the reason code unconditionally:

```js
packet.reasonCode = this._parseByte()
if (!constants.MQTT5_AUTH_CODES[packet.reasonCode]) {
  return this._emitError(new Error('Invalid auth reason code'))
}
```

With Remaining Length 0 there is no reason-code byte, so `_parseByte()` returns `undefined`, `MQTT5_AUTH_CODES[undefined]` is falsy, and the packet is dropped. The sibling `_parseDisconnect()` already handles the analogous DISCONNECT `e0 00` case by guarding the read with `if (this._list.length > 0)` and defaulting the reason code to `0`; AUTH is the only reason-code packet missing that guard.

### Impact
A spec-compliant minimal Success AUTH from a broker or client doing enhanced/re-authentication is rejected as an error, breaking the auth handshake when interoperating with peers that use the minimal encoding (affects MQTT.js and Aedes). `generate()` is unaffected — it always emits the longer `f0 02 00 00` form — which is why a self round-trip never exposed this; the minimal form only arrives from an external encoder.

### Fix
Mirror the existing `_parseDisconnect` guard: only read/validate the reason code when bytes remain, otherwise default it to `0`. Non-empty AUTH packets (including invalid reason codes) behave exactly as before.

### Tests
Added a parse-only case for `f0 00` asserting `{ cmd: 'auth', reasonCode: 0, length: 0 }`. The full suite passes (668) and `standard` is clean.
