### PR TITLE
fix: preserve duplicate user properties with empty-string value

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -761,7 +761,7 @@ class Parser extends EventEmitter {
           result[name] = Object.create(null)
         }
         const currentUserProperty = this._parseByType(constants.propertiesTypes[name])
-        if (result[name][currentUserProperty.name]) {
+        if (result[name][currentUserProperty.name] !== undefined) {
           if (Array.isArray(result[name][currentUserProperty.name])) {
             result[name][currentUserProperty.name].push(currentUserProperty.value)
           } else {

--- a/test.js
+++ b/test.js
@@ -1594,6 +1594,28 @@ testParseGenerate('publish MQTT 5 with multiple same properties', {
   116, 101, 115, 116 // Payload (test)
 ]), { protocolVersion: 5 })
 
+testParseGenerate('publish MQTT 5 with duplicate user property including empty-string value', {
+  cmd: 'publish',
+  retain: false,
+  qos: 0,
+  dup: false,
+  length: 18,
+  topic: 't',
+  payload: Buffer.from('x'),
+  properties: {
+    userProperties: {
+      a: ['', 'b']
+    }
+  }
+}, Buffer.from([
+  48, 18, // Header
+  0, 1, 116, // Topic length + 't'
+  13, // properties length
+  38, 0, 1, 97, 0, 0, // userProperties a -> ''
+  38, 0, 1, 97, 0, 1, 98, // userProperties a -> 'b'
+  120 // Payload (x)
+]), { protocolVersion: 5 })
+
 testParseGenerate('publish MQTT 5 properties with 0-4 byte varbyte', {
   cmd: 'publish',
   retain: true,


### PR DESCRIPTION
The MQTT 5 parser aggregates repeated User Properties sharing a name using a truthiness check on the previously stored value. An empty string is a valid zero-length UTF-8 string but is falsy, so a following occurrence of the same name takes the first-insert branch and overwrites it instead of appending — silently dropping the empty value and collapsing the array to a scalar.

Repro: parsing a PUBLISH carrying user properties `a=""` then `a="b"` yields `{ a: 'b' }` instead of `{ a: ['', 'b'] }`. `generate` emits both pairs correctly; only the parser loses data, so `generate → parse` is not a round-trip.

Use an explicit `!== undefined` presence check so every value is retained, per MQTT 5.0 §3.3.2.3.7 (a User Property name may appear more than once) and §1.5.4 (UTF-8 encoded strings may be zero length). Adds a regression test.
